### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,0 +1,103 @@
+name: Build binaries
+
+on: [push, pull_request]
+
+jobs:
+
+  build-linux-aarch64:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install
+        run: |
+          rustup target add aarch64-unknown-linux-gnu
+          sudo apt-get update ; sudo apt-get install gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu gcc-aarch64-linux-gnu
+      
+      - name: Compile
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: /usr/bin/aarch64-linux-gnu-gcc
+        run: |
+          cargo build --release --target=aarch64-unknown-linux-gnu
+
+      - name: Copy around
+        run: | 
+          mkdir release
+          cp target/aarch64-unknown-linux-gnu/release/hanachan release/hanachan_linux_aarch64 || /bin/true
+
+      - name: Upload distribution
+        uses: actions/upload-artifact@v2
+        with:
+          name: release
+          path: | 
+            release
+
+
+  build-linux-windows:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install
+        run: |
+          rustup target add i686-unknown-linux-gnu
+          rustup target add x86_64-unknown-linux-gnu
+          #
+          rustup target add i686-pc-windows-gnu
+          rustup target add x86_64-pc-windows-gnu
+          sudo apt-get update ; sudo apt-get install mingw-w64 gcc-multilib
+      
+      - name: Compile
+        run: |
+          cargo build --release --target=i686-unknown-linux-gnu
+          cargo build --release --target=x86_64-unknown-linux-gnu
+          #
+          RUSTFLAGS="-C panic=abort -C embed-bitcode=yes -C lto" cargo build --release --target=i686-pc-windows-gnu
+          cargo build --release --target=x86_64-pc-windows-gnu
+
+      - name: Copy around
+        run: | 
+          mkdir release
+          cp target/i686-unknown-linux-gnu/release/hanachan release/hanachan_linux_i686 || /bin/true
+          cp target/x86_64-unknown-linux-gnu/release/hanachan release/hanachan_linux_x86_64 || /bin/true
+          #
+          cp target/i686-pc-windows-gnu/release/hanachan.exe release/hanachan_windows_i686.exe || /bin/true
+          cp target/x86_64-pc-windows-gnu/release/hanachan.exe release/hanachan_windows_x86_64.exe || /bin/true
+
+      - name: Upload distribution
+        uses: actions/upload-artifact@v2
+        with:
+          name: release
+          path: | 
+            release
+
+  build-osx:
+    runs-on: macos-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install
+        run: |
+          rustup target add x86_64-apple-darwin
+          # rustup target add aarch64-apple-darwin
+      
+      - name: Compile
+        run: |
+          cargo build --release --target=x86_64-apple-darwin
+          # cargo build --release --target=aarch64-apple-darwin
+
+      - name: Copy around
+        run: | 
+          mkdir release
+          cp target/x86_64-apple-darwin/release/hanachan release/hanachan_mac_x86_64 || /bin/true
+          # cp target/aarch64-apple-darwin/release/hanachan release/hanachan_mac_aarch64 || /bin/true
+
+      - name: Upload distribution
+        uses: actions/upload-artifact@v2
+        with:
+          name: release
+          path: | 
+            release


### PR DESCRIPTION
Here's a Github Actions config that will automatically build binaries for Linux, Mac and Windows with each commit. 

I tested the Linux and Windows binaries and they both work, I currently don't have a Mac to test the Mac version on. 

I tried to make 32-bit versions for Linux & Windows, and an ARM version for Mac, too, but the code seems to use some x86_64-only code and I don't know enough Rust to potentially fix that.